### PR TITLE
Make celery service template more flexible for things like flower, an…

### DIFF
--- a/templates/celery.service.j2
+++ b/templates/celery.service.j2
@@ -12,7 +12,7 @@ EnvironmentFile={{celery_env_dir}}/{{item.name}}
 WorkingDirectory={{celery_working_dir}}
 ExecStart=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_START} ${CELERYD_NODES} -A ${CELERY_APP} ${CELERYD_OPTS}'
 {% if item.multi is defined -%}
-ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES}'
+ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES} ${CELERYD_OPTS}'
 ExecReload=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_RESTART} ${CELERYD_NODES} -A ${CELERY_APP} ${CELERYD_OPTS}'
 {% endif %}
 

--- a/templates/celery.service.j2
+++ b/templates/celery.service.j2
@@ -10,33 +10,10 @@ User={{celery_user}}
 Group={{celery_user}}
 EnvironmentFile={{celery_env_dir}}/{{item.name}}
 WorkingDirectory={{celery_working_dir}}
-ExecStart=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_START} ${CELERYD_NODES} \
-  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celery_extra_args is defined or item.celery_pidfile is defined %} \
-{% else %}'
-{% endif %}
-{% if item.celery_extra_args is defined %}
-  {{item.celery_extra_args}} \
-{% endif %}
-{% if item.celery_pidfile is defined %}
-  --pidfile={{item.celery_pidfile}}'
-{% endif %}
+ExecStart=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_START} ${CELERYD_NODES} -A ${CELERY_APP} ${CELERYD_OPTS}'
 {% if item.multi is defined -%}
-ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES}{% if item.celery_pidfile is defined %} \
-{% else %}'
-{% endif %}
-{% if item.celery_pidfile is defined %}
-  --pidfile={{item.celery_pidfile}}'
-{% endif %}
-ExecReload=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_RESTART} ${CELERYD_NODES} \
-  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celery_extra_args is defined or item.celery_pidfile is defined %} \
-{% else %}'
-{% endif %}
-{% if item.celery_extra_args is defined %}
-  {{item.celery_extra_args}} \
-{% endif %}
-{% if item.celery_pidfile is defined %}
-  --pidfile={{item.celery_pidfile}}'
-{% endif %}
+ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES}'
+ExecReload=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_RESTART} ${CELERYD_NODES} -A ${CELERY_APP} ${CELERYD_OPTS}'
 {% endif %}
 
 [Install]

--- a/templates/celery.service.j2
+++ b/templates/celery.service.j2
@@ -11,13 +11,46 @@ Group={{celery_user}}
 EnvironmentFile={{celery_env_dir}}/{{item.name}}
 WorkingDirectory={{celery_working_dir}}
 ExecStart=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_START} ${CELERYD_NODES} \
-  -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
-ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES} \
-  --pidfile=${CELERYD_PID_FILE}'
+  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celeryd_logfile is defined or item.celerybeat_logfile is defined or item.celeryd_pidfile is defined or item.celerybeat_pidfile is defined %} \
+{% else %}'
+{% endif %}
+{% if item.celeryd_logfile is defined %}
+  --logfile={{item.celeryd_logfile}} --loglevel={{item.celeryd_loglevel}} \
+{% endif %}
+{% if item.celerybeat_logfile is defined %}
+  --logfile={{item.celerybeat_logfile}} --loglevel={{item.celerybeat_loglevel}} \
+{% endif %}
+{% if item.celeryd_pidfile is defined %}
+  --pidfile={{item.celeryd_pidfile}}'
+{% endif %}
+{% if item.celerybeat_pidfile is defined %}
+  --pidfile={{item.celerybeat_pidfile}}'
+{% endif %}
+ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES}{% if item.celeryd_pidfile is defined or item.celerybeat_pidfile is defined %} \
+{% else %}'
+{% endif %}
+{% if item.celeryd_pidfile is defined %}
+  --pidfile={{item.celeryd_pidfile}}'
+{% endif %}
+{% if item.celerybeat_pidfile is defined %}
+  --pidfile={{item.celerybeat_pidfile}}'
+{% endif %}
 ExecReload=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_RESTART} ${CELERYD_NODES} \
-  -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
+  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celeryd_logfile is defined or item.celerybeat_logfile is defined or item.celeryd_pidfile is defined or item.celerybeat_pidfile is defined %} \
+{% else %}'
+{% endif %}
+{% if item.celeryd_logfile is defined %}
+  --logfile={{item.celeryd_logfile}} --loglevel={{item.celeryd_loglevel}} \
+{% endif %}
+{% if item.celerybeat_logfile is defined %}
+  --logfile={{item.celerybeat_logfile}} --logfile={{item.celerybeat_loglevel}} \
+{% endif %}
+{% if item.celeryd_pidfile is defined %}
+  --pidfile={{item.celeryd_pidfile}}'
+{% endif %}
+{% if item.celerybeat_pidfile is defined %}
+  --pidfile={{item.celerybeat_pidfile}}'
+{% endif %}
 
 [Install]
 WantedBy=celery.target

--- a/templates/celery.service.j2
+++ b/templates/celery.service.j2
@@ -20,6 +20,7 @@ ExecStart=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_START} ${CELERYD_NODES} \
 {% if item.celery_pidfile is defined %}
   --pidfile={{item.celery_pidfile}}'
 {% endif %}
+{% if item.multi is defined -%}
 ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES}{% if item.celery_pidfile is defined %} \
 {% else %}'
 {% endif %}
@@ -35,6 +36,7 @@ ExecReload=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_RESTART} ${CELERYD_NODES} \
 {% endif %}
 {% if item.celery_pidfile is defined %}
   --pidfile={{item.celery_pidfile}}'
+{% endif %}
 {% endif %}
 
 [Install]

--- a/templates/celery.service.j2
+++ b/templates/celery.service.j2
@@ -11,45 +11,30 @@ Group={{celery_user}}
 EnvironmentFile={{celery_env_dir}}/{{item.name}}
 WorkingDirectory={{celery_working_dir}}
 ExecStart=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_START} ${CELERYD_NODES} \
-  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celeryd_logfile is defined or item.celerybeat_logfile is defined or item.celeryd_pidfile is defined or item.celerybeat_pidfile is defined %} \
+  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celery_extra_args is defined or item.celery_pidfile is defined %} \
 {% else %}'
 {% endif %}
-{% if item.celeryd_logfile is defined %}
-  --logfile={{item.celeryd_logfile}} --loglevel={{item.celeryd_loglevel}} \
+{% if item.celery_extra_args is defined %}
+  {{item.celery_extra_args}} \
 {% endif %}
-{% if item.celerybeat_logfile is defined %}
-  --logfile={{item.celerybeat_logfile}} --loglevel={{item.celerybeat_loglevel}} \
+{% if item.celery_pidfile is defined %}
+  --pidfile={{item.celery_pidfile}}'
 {% endif %}
-{% if item.celeryd_pidfile is defined %}
-  --pidfile={{item.celeryd_pidfile}}'
-{% endif %}
-{% if item.celerybeat_pidfile is defined %}
-  --pidfile={{item.celerybeat_pidfile}}'
-{% endif %}
-ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES}{% if item.celeryd_pidfile is defined or item.celerybeat_pidfile is defined %} \
+ExecStop=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_STOP} ${CELERYD_NODES}{% if item.celery_pidfile is defined %} \
 {% else %}'
 {% endif %}
-{% if item.celeryd_pidfile is defined %}
-  --pidfile={{item.celeryd_pidfile}}'
-{% endif %}
-{% if item.celerybeat_pidfile is defined %}
-  --pidfile={{item.celerybeat_pidfile}}'
+{% if item.celery_pidfile is defined %}
+  --pidfile={{item.celery_pidfile}}'
 {% endif %}
 ExecReload=/bin/sh -c '${CELERY_BIN} ${CELERY_MULTI_RESTART} ${CELERYD_NODES} \
-  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celeryd_logfile is defined or item.celerybeat_logfile is defined or item.celeryd_pidfile is defined or item.celerybeat_pidfile is defined %} \
+  -A ${CELERY_APP} ${CELERYD_OPTS}{% if item.celery_extra_args is defined or item.celery_pidfile is defined %} \
 {% else %}'
 {% endif %}
-{% if item.celeryd_logfile is defined %}
-  --logfile={{item.celeryd_logfile}} --loglevel={{item.celeryd_loglevel}} \
+{% if item.celery_extra_args is defined %}
+  {{item.celery_extra_args}} \
 {% endif %}
-{% if item.celerybeat_logfile is defined %}
-  --logfile={{item.celerybeat_logfile}} --logfile={{item.celerybeat_loglevel}} \
-{% endif %}
-{% if item.celeryd_pidfile is defined %}
-  --pidfile={{item.celeryd_pidfile}}'
-{% endif %}
-{% if item.celerybeat_pidfile is defined %}
-  --pidfile={{item.celerybeat_pidfile}}'
+{% if item.celery_pidfile is defined %}
+  --pidfile={{item.celery_pidfile}}'
 {% endif %}
 
 [Install]


### PR DESCRIPTION
…d beat

allows us to define logging/pidfiles for celery and beat, and not for flower. 

There's a corresponding PR in Ansible to update group_vars to fit this template, which this cannot be merged without. (https://github.com/singleplatform/ansible/pull/867)